### PR TITLE
feat: Add video after toggling all settings

### DIFF
--- a/android/app/src/main/kotlin/com/example/minimo_video/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/minimo_video/MainActivity.kt
@@ -224,7 +224,6 @@ class MainActivity : FlutterActivity() {
             }
         }
         data.data?.let { uris.add(it) }
-        File(cacheDir, "picked_videos").deleteRecursively()
         Log.i(TAG, "Importing ${uris.size} videos sequentially")
         sendPickProgress(0, uris.size)
         return uris.mapIndexed { index, uri ->

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -52,4 +52,4 @@ Save, share, deletion, result semantics, errors, and known limitations.
 
 ---
 
-*Last updated: July 31, 2026 · v1.0.1+13*
+*Last updated: August 1, 2026 · v1.0.1+13*

--- a/docs/skills/core/architecture.md
+++ b/docs/skills/core/architecture.md
@@ -34,7 +34,7 @@ CompressScreen
         → native Android/iOS codecs
 ```
 
-`CompressBloc` owns settings, estimates, batch order, status per video, progress, cancellation, results, saving, and deletion. Videos are compressed sequentially. Overall progress is weighted by input file size.
+`CompressBloc` owns the selected batch, settings, estimates, status per video, progress, cancellation, results, saving, and deletion. `CompressVideosAdded` appends newly picked files only while the Bloc is `ready`, extends the aligned thumbnail/status lists, and schedules fresh thumbnails and an estimate without resetting settings. Videos are compressed sequentially. Overall progress is weighted by input file size.
 
 ## Platform Channel
 
@@ -51,11 +51,12 @@ Channel `minimo_video/thermal` exposes `currentState` for overheating warnings.
 
 ## File Lifecycle
 
-1. Picker copies selected files into temporary `picked_videos` storage.
-2. Compressor writes MP4 output into temporary `minimo_video` storage.
-3. Output saving uses `gal`; sharing uses `share_plus`.
-4. Outputs saving less than 10% are deleted and marked skipped.
-5. App and compressor temporary files are cleared on every cold start.
+1. The start screen or the compression screen's `ready` state opens the same source sheet and native picker.
+2. Picker copies selected files into temporary `picked_videos` storage. Picks made during configuration are appended to the current batch.
+3. Compressor writes MP4 output into temporary `minimo_video` storage.
+4. Output saving uses `gal`; sharing uses `share_plus`.
+5. Outputs saving less than 10% are deleted and marked skipped.
+6. App and compressor temporary files are cleared on every cold start.
 
 ## Generated Files
 

--- a/docs/skills/core/overview.md
+++ b/docs/skills/core/overview.md
@@ -4,7 +4,7 @@
 
 ## Current Capabilities
 
-- Select one or multiple local videos
+- Select one or multiple local videos and append more while configuring compression
 - High, medium, and low quality presets
 - Manual resolution and audio controls
 - Sequential batch compression with overall and per-video progress
@@ -30,6 +30,7 @@
 | Routing | `lib/router/app_router.dart` |
 | Main selection screen | `lib/screens/start_page.dart` |
 | Compression feature | `lib/features/compression/` |
+| Shared video loading UI | `lib/features/compression/presentation/widgets/video_loading_view.dart` |
 | Persistent settings | `lib/services/app_settings_service.dart` |
 
 ---

--- a/docs/skills/core/testing.md
+++ b/docs/skills/core/testing.md
@@ -13,6 +13,7 @@ git diff --check
 Current tests cover:
 
 - Quality preset mapping to internal tier and resolution
+- Appending only new picked videos while preserving settings and aligned batch state
 - Compression estimate formula and audio contribution
 - Minimum 10% output-savings policy
 - Batch status transitions and mixed success/skipped results
@@ -22,6 +23,7 @@ Current tests cover:
 - Compression failure state
 - Cache size and full cleanup
 - Preview styling, status percentage, press motion, and hold-button background
+- Add-more and compress actions sharing the settings bottom row
 - Compact icon-only `AppActionButton` layout for wide SVG assets (`arrow_back`, `share`, `more`)
 
 ## Test Boundaries
@@ -42,6 +44,7 @@ Native behavior needs focused manual checks when compression or platform code ch
 - Already optimized input is skipped when savings are below 10%
 - Save, share, and delete-original flows show expected system UI
 - Multi-select preserves filenames and handles duplicate names
+- Adding videos from both gallery and files during configuration preserves the existing batch and settings, refreshes previews/estimate, and reports copy progress
 
 Simulator tests are insufficient for codec, thermal, and real Photos/MediaStore behavior.
 

--- a/docs/skills/features/compression.md
+++ b/docs/skills/features/compression.md
@@ -27,7 +27,7 @@ Retained audio is encoded as AAC at 128 kbps. Do not switch back to passthrough:
 
 ## Pipeline
 
-1. Native picker copies selected video to app cache.
+1. Native picker copies selected videos to app cache.
 2. `VideoCompressorAdapter` maps settings to `light_compressor_v2`.
 3. Plugin compresses with native Android/iOS codecs.
 4. Progress stream is normalized from `0–100` to `0–1`.
@@ -37,6 +37,14 @@ Retained audio is encoded as AAC at 128 kbps. Do not switch back to passthrough:
 `BackgroundConfig` keeps compression running through an Android foreground service when the app is minimized or the screen is off. iOS does not support continuous background transcoding; the native job can remain stuck after the OS suspends the app.
 
 On iOS the compression screen warns the user to keep the app open. If the app is backgrounded during compression, the active native job is cancelled immediately; returning restarts only the current video and keeps completed batch items.
+
+## Adding Videos During Configuration
+
+The plus action beside the bottom compress button is available only in `CompressStatus.ready`. It uses the same gallery/files source sheet and `VideoFileAdapter.pickVideos` path as the start screen. While native files are copied, the settings content is replaced by the shared `VideoLoadingView`, picker progress is shown when available, and route popping is blocked.
+
+Picked videos are appended through `CompressVideosAdded`; existing compression settings remain unchanged. Videos already in the batch are ignored: provider `sourceIdentifier` is the primary identity, with original filename plus file size as the fallback for providers that do not expose an identifier. The same filtering also removes duplicates returned in one additional pick.
+
+The Bloc keeps `videos`, `thumbnailPaths`, and `videoStatuses` aligned, requests thumbnails for the first three items, invalidates any stale asynchronous estimate, and computes a new estimate for the expanded batch. Empty, cancelled, or duplicate-only picker results leave the batch unchanged. Adding files is not available during processing or on the result screen.
 
 ## Estimates
 

--- a/docs/skills/features/platform.md
+++ b/docs/skills/features/platform.md
@@ -2,7 +2,7 @@
 
 ## Media Selection
 
-The start screen shows a source sheet (`from gallery` / `from files`) before opening a native picker. Flutter passes `source` (`gallery` | `files`) to `pickVideos`.
+The start screen and the compression screen's add-more action show the same source sheet (`from gallery` / `from files`) before opening a native picker. Flutter passes `source` (`gallery` | `files`) to `pickVideos`. Selection from the compression screen is restricted to the pre-compression `ready` state and appends files to the existing batch.
 
 ### iOS
 
@@ -16,7 +16,7 @@ Selected files are imported sequentially to avoid parallel disk/memory pressure.
 - **Gallery:** system photo picker (`MediaStore.ACTION_PICK_IMAGES`, `video/*`) on Android 13+; `ACTION_GET_CONTENT` + `video/*` on older versions.
 - **Files:** `ACTION_OPEN_DOCUMENT`, `video/*`, multi-selection.
 
-Selected URIs are copied sequentially into app cache on a background thread with a 1 MB buffer.
+Selected URIs are copied sequentially into app cache on a background thread with a 1 MB buffer. A later add-more pick must not clear `picked_videos`, because the existing batch still references those cached copies; cold-start cleanup owns removal of the directory.
 
 Both platforms report `pickProgress` (`processed`/`total`) over the videos method channel while files are imported.
 

--- a/docs/skills/features/results-and-errors.md
+++ b/docs/skills/features/results-and-errors.md
@@ -47,7 +47,7 @@ Delete originals is reached from the done-screen more sheet through `HoldToConfi
 
 ## Known Limitations
 
-- `light_compressor_v2` is pinned to `1.0.0` for current Dart compatibility.
+- `light_compressor_v2` is pinned to `1.9.0`; update it deliberately and repeat physical-device codec checks.
 - Installing/changing a native plugin requires a full rebuild; hot reload cannot register new platform channels.
 - Already compressed inputs are re-encoded before the 10% policy decides whether to keep output.
 - Estimates are bitrate-based approximations, not guarantees.

--- a/docs/skills/ui/screens.md
+++ b/docs/skills/ui/screens.md
@@ -7,7 +7,7 @@ Routes use `auto_route` with fade transitions.
 | `SplashRoute` | Resolve first-launch destination |
 | `OnboardingRoute` | Explain local selection, quality, and privacy |
 | `StartRoute` | Choose gallery or files, select one or more videos, show store update and changelog prompts |
-| `CompressRoute` | Configure, run, cancel, save, share, or delete originals |
+| `CompressRoute` | Add more videos, configure, run, cancel, save, share, or delete originals |
 | `SettingsRoute` | Filename prefix, thermal warning, album, cache, language |
 | `InfoRoute` | App/version information, rating, sharing, and external links |
 
@@ -17,15 +17,15 @@ Settings and info are presented as 90%-height sheets via `stupid_simple_sheet` (
 
 The screen renders from `CompressStatus`:
 
-- `ready` → simple/advanced settings and full-width compress action
+- `ready` → simple/advanced settings and a bottom action row with add-more and compress
 - `processing` → size estimate, overall progress, current-file percentage, status list, hold-to-cancel
 - `done` → results, saved space, and compact post-compression actions
 
 ### Navigation chrome
 
-`CompressScreen` owns the top-left icon-only back button for `ready` and `done`. It uses the `AppActionButton` text variant (no border or fill). Back is hidden during `processing`.
+`CompressScreen` owns the top-left icon-only back button for `ready` and `done`. It uses the `AppActionButton` text variant (no border or fill). Navigation chrome is hidden during `processing` and while picked videos are copied into cache.
 
-During `processing`, `PopScope(canPop: false)` blocks route pops, including Android system back and the iOS edge-swipe gesture. Hold-to-cancel is the only exit back to settings.
+During `processing` and add-more file copying, `PopScope(canPop: false)` blocks route pops, including Android system back and the iOS edge-swipe gesture. Hold-to-cancel is the only exit from processing back to settings; copying must finish or fail before navigation resumes.
 
 ### Done-screen actions
 
@@ -38,7 +38,7 @@ On a successful result:
 
 Failed compression replaces save with retry and keeps the more menu. Already-optimized results keep the more menu without a primary filled action.
 
-`CompressionBottomActions` on the settings screen is compress-only; back lives in the shared top chrome.
+`CompressionBottomActions` places an outlined icon-only plus button and the filled compress button in the same bottom row. The plus button opens the same gallery/files source sheet as `StartRoute`, appends selected videos, and refreshes thumbnails and the size estimate without resetting compression settings. Back remains in the shared top chrome.
 
 Simple presets are the primary UX. Advanced mode currently exposes only resolution and audio.
 

--- a/lib/features/compression/bloc/compress_bloc.dart
+++ b/lib/features/compression/bloc/compress_bloc.dart
@@ -38,6 +38,7 @@ class CompressBloc extends Bloc<CompressEvent, CompressState> {
        super(CompressState.initial(initialVideos)) {
     on<CompressThumbnailsRequested>(_onThumbnailsRequested);
     on<CompressEstimateRequested>(_onEstimateRequested);
+    on<CompressVideosAdded>(_onVideosAdded);
     on<CompressSimpleQualityChanged>(_onSimpleQualityChanged);
     on<CompressResolutionChanged>(_onResolutionChanged);
     on<CompressSettingsChanged>(_onSettingsChanged);
@@ -80,17 +81,65 @@ class CompressBloc extends Bloc<CompressEvent, CompressState> {
     CompressThumbnailsRequested event,
     Emitter<CompressState> emit,
   ) async {
-    final thumbnails = List<String?>.of(state.thumbnailPaths);
     final count = state.videos.length < 3 ? state.videos.length : 3;
 
     for (var i = 0; i < count; i++) {
       if (state.status != CompressStatus.ready) return;
+      if (i < state.thumbnailPaths.length && state.thumbnailPaths[i] != null) {
+        continue;
+      }
       final path = await _videoCompressorAdapter.createThumbnail(
         state.videos[i].path,
       );
+      if (state.status != CompressStatus.ready ||
+          i >= state.thumbnailPaths.length) {
+        return;
+      }
+      final thumbnails = List<String?>.of(state.thumbnailPaths);
       thumbnails[i] = path;
       emit(state.copyWith(thumbnailPaths: thumbnails));
     }
+  }
+
+  void _onVideosAdded(CompressVideosAdded event, Emitter<CompressState> emit) {
+    if (state.status != CompressStatus.ready || event.videos.isEmpty) return;
+
+    final identities = state.videos.map(_videoIdentity).toSet();
+    final addedVideos = <PickedVideo>[];
+    for (final video in event.videos) {
+      if (identities.add(_videoIdentity(video))) {
+        addedVideos.add(video);
+      }
+    }
+    if (addedVideos.isEmpty) return;
+
+    emit(
+      state.copyWith(
+        videos: [...state.videos, ...addedVideos],
+        thumbnailPaths: [
+          ...state.thumbnailPaths,
+          ...List<String?>.filled(addedVideos.length, null),
+        ],
+        videoStatuses: [
+          ...state.videoStatuses,
+          ...List<VideoCompressionStatus>.filled(
+            addedVideos.length,
+            VideoCompressionStatus.waiting,
+          ),
+        ],
+        clearEstimatedSize: true,
+      ),
+    );
+    add(const CompressThumbnailsRequested());
+    _requestEstimate();
+  }
+
+  String _videoIdentity(PickedVideo video) {
+    final sourceIdentifier = video.sourceIdentifier;
+    if (sourceIdentifier != null && sourceIdentifier.isNotEmpty) {
+      return 'source:$sourceIdentifier';
+    }
+    return 'file:${video.name}\u0000${video.size}';
   }
 
   void _onSimpleQualityChanged(

--- a/lib/features/compression/bloc/compress_event.dart
+++ b/lib/features/compression/bloc/compress_event.dart
@@ -1,4 +1,5 @@
 import '../domain/compression_settings.dart';
+import '../domain/picked_video.dart';
 
 abstract class CompressEvent {
   const CompressEvent();
@@ -16,6 +17,12 @@ class CompressThumbnailsRequested extends CompressEvent {
 
 class CompressEstimateRequested extends CompressEvent {
   const CompressEstimateRequested();
+}
+
+class CompressVideosAdded extends CompressEvent {
+  final List<PickedVideo> videos;
+
+  const CompressVideosAdded(this.videos);
 }
 
 class CompressResolutionChanged extends CompressEvent {

--- a/lib/features/compression/presentation/compress_screen.dart
+++ b/lib/features/compression/presentation/compress_screen.dart
@@ -15,10 +15,13 @@ import '../../../widgets/minimo_loader.dart';
 import '../bloc/compress_bloc.dart';
 import '../bloc/compress_event.dart';
 import '../bloc/compress_state.dart';
+import '../data/video_file_adapter.dart';
 import '../domain/picked_video.dart';
 import 'widgets/compression_progress_view.dart';
 import 'widgets/compression_result_view.dart';
 import 'widgets/compression_settings_view.dart';
+import 'widgets/video_loading_view.dart';
+import 'widgets/video_pick_source_sheet.dart';
 
 @RoutePage()
 class CompressScreen extends StatelessWidget {
@@ -74,8 +77,11 @@ class _CompressView extends StatefulWidget {
 
 class _CompressViewState extends State<_CompressView>
     with WidgetsBindingObserver {
+  final _videoFileAdapter = VideoFileAdapter();
   var _backgroundedWhileProcessing = false;
   int? _reviewRequestedForRunId;
+  bool _loadingVideos = false;
+  (int, int)? _loadingProgress;
 
   @override
   void initState() {
@@ -116,7 +122,7 @@ class _CompressViewState extends State<_CompressView>
       },
       builder: (context, state) {
         return PopScope(
-          canPop: state.status != CompressStatus.processing,
+          canPop: state.status != CompressStatus.processing && !_loadingVideos,
           child: Scaffold(
             backgroundColor: Theme.of(context).colorScheme.surface,
             body: SafeArea(
@@ -124,37 +130,44 @@ class _CompressViewState extends State<_CompressView>
                 padding: const EdgeInsets.fromLTRB(22, 18, 22, 14),
                 child: Column(
                   children: [
-                    if (state.status != CompressStatus.processing) ...[
-                      Align(
-                        alignment: Alignment.centerLeft,
-                        child: AppActionButton(
-                          width: 47,
-                          icon: AppIcons.arrowBack,
-                          iconWidth: 22,
-                          iconHeight: 22,
-                          variant: AppActionButtonVariant.text,
-                          onPressed: () => _goToStart(context),
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                    ],
-                    Expanded(
-                      child: switch (state.status) {
-                        CompressStatus.ready => CompressionSettingsView(
-                          state: state,
-                        ),
-                        CompressStatus.processing => CompressionProgressView(
-                          key: ValueKey(state.compressionRunId),
-                          state: state,
-                        ),
-                        CompressStatus.done => CompressionResultView(
-                          state: state,
-                          onTryAgain: () => context.read<CompressBloc>().add(
-                            const CompressStarted(),
+                    if (_loadingVideos)
+                      Expanded(
+                        child: VideoLoadingView(progress: _loadingProgress),
+                      )
+                    else ...[
+                      if (state.status != CompressStatus.processing) ...[
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: AppActionButton(
+                            width: 47,
+                            icon: AppIcons.arrowBack,
+                            iconWidth: 22,
+                            iconHeight: 22,
+                            variant: AppActionButtonVariant.text,
+                            onPressed: () => _goToStart(context),
                           ),
                         ),
-                      },
-                    ),
+                        const SizedBox(height: 8),
+                      ],
+                      Expanded(
+                        child: switch (state.status) {
+                          CompressStatus.ready => CompressionSettingsView(
+                            state: state,
+                            onAddVideos: () => unawaited(_pickMoreVideos()),
+                          ),
+                          CompressStatus.processing => CompressionProgressView(
+                            key: ValueKey(state.compressionRunId),
+                            state: state,
+                          ),
+                          CompressStatus.done => CompressionResultView(
+                            state: state,
+                            onTryAgain: () => context.read<CompressBloc>().add(
+                              const CompressStarted(),
+                            ),
+                          ),
+                        },
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -163,6 +176,37 @@ class _CompressViewState extends State<_CompressView>
         );
       },
     );
+  }
+
+  Future<void> _pickMoreVideos() async {
+    final source = await showVideoPickSourceSheet(context);
+    if (source == null || !mounted) return;
+
+    setState(() {
+      _loadingVideos = true;
+      _loadingProgress = null;
+    });
+
+    try {
+      final videos = await _videoFileAdapter.pickVideos(
+        source: source,
+        onProgress: (processed, total) {
+          if (mounted) {
+            setState(() => _loadingProgress = (processed, total));
+          }
+        },
+      );
+      if (videos.isNotEmpty && mounted) {
+        context.read<CompressBloc>().add(CompressVideosAdded(videos));
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loadingVideos = false;
+          _loadingProgress = null;
+        });
+      }
+    }
   }
 
   void _requestReviewAfterSuccessfulCompression(CompressState state) {

--- a/lib/features/compression/presentation/widgets/compression_bottom_actions.dart
+++ b/lib/features/compression/presentation/widgets/compression_bottom_actions.dart
@@ -1,23 +1,40 @@
 import 'package:flutter/material.dart';
 
+import '../../../../constants/app_icons.dart';
 import '../../../../generated/l10n.dart';
 import '../../../../widgets/app_action_button.dart';
 
 class CompressionBottomActions extends StatelessWidget {
+  final VoidCallback onAdd;
   final VoidCallback onCompress;
 
-  const CompressionBottomActions({super.key, required this.onCompress});
+  const CompressionBottomActions({
+    super.key,
+    required this.onAdd,
+    required this.onCompress,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 47,
-      width: double.infinity,
-      child: AppActionButton(
-        label: S.of(context).compress,
-        variant: AppActionButtonVariant.filled,
-        onPressed: onCompress,
-      ),
+    return Row(
+      children: [
+        AppActionButton(
+          width: 47,
+          icon: AppIcons.plus,
+          iconWidth: 22,
+          iconHeight: 22,
+          onPressed: onAdd,
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: AppActionButton(
+            width: double.infinity,
+            label: S.of(context).compress,
+            variant: AppActionButtonVariant.filled,
+            onPressed: onCompress,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/compression/presentation/widgets/compression_settings_view.dart
+++ b/lib/features/compression/presentation/widgets/compression_settings_view.dart
@@ -26,8 +26,13 @@ import 'simple_quality_card.dart';
 
 class CompressionSettingsView extends StatefulWidget {
   final CompressState state;
+  final VoidCallback onAddVideos;
 
-  const CompressionSettingsView({super.key, required this.state});
+  const CompressionSettingsView({
+    super.key,
+    required this.state,
+    required this.onAddVideos,
+  });
 
   @override
   State<CompressionSettingsView> createState() =>
@@ -173,6 +178,7 @@ class _CompressionSettingsViewState extends State<CompressionSettingsView> {
         ),
         const SizedBox(height: 12),
         CompressionBottomActions(
+          onAdd: widget.onAddVideos,
           onCompress: () =>
               context.read<CompressBloc>().add(const CompressStarted()),
         ),

--- a/lib/features/compression/presentation/widgets/video_loading_view.dart
+++ b/lib/features/compression/presentation/widgets/video_loading_view.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../../../../generated/l10n.dart';
+import '../../../../theme/app_theme.dart';
+import '../../../../widgets/minimo_loader.dart';
+
+class VideoLoadingView extends StatelessWidget {
+  final (int, int)? progress;
+
+  const VideoLoadingView({super.key, this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    final materialTheme = Theme.of(context);
+    final theme = AppTheme.of(context);
+    final strings = S.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            MinimoLoader(size: 58, semanticsLabel: strings.loadingVideos),
+            const SizedBox(height: 18),
+            Text(
+              strings.loadingVideos,
+              textAlign: TextAlign.center,
+              style: materialTheme.textTheme.titleMedium?.copyWith(
+                color: theme.textColor,
+              ),
+            ),
+            if (progress case (final done, final total)) ...[
+              const SizedBox(height: 8),
+              Text(
+                '$done / $total',
+                style: materialTheme.textTheme.titleLarge?.copyWith(
+                  color: theme.textColor,
+                ),
+              ),
+            ],
+            const SizedBox(height: 8),
+            Text(
+              strings.loadingManyVideosHint,
+              textAlign: TextAlign.center,
+              style: materialTheme.textTheme.bodyMedium?.copyWith(
+                color: theme.textColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/start_page.dart
+++ b/lib/screens/start_page.dart
@@ -8,6 +8,7 @@ import 'package:upgrader/upgrader.dart';
 
 import '../constants/app_icons.dart';
 import '../features/compression/data/video_file_adapter.dart';
+import '../features/compression/presentation/widgets/video_loading_view.dart';
 import '../features/compression/presentation/widgets/video_pick_source_sheet.dart';
 import '../generated/l10n.dart';
 import '../router/app_router.gr.dart';
@@ -16,7 +17,6 @@ import '../services/changelog_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/bottom_frame.dart';
 import '../widgets/changelog_dialog.dart';
-import '../widgets/minimo_loader.dart';
 import '../widgets/pressable.dart';
 
 @RoutePage()
@@ -168,47 +168,7 @@ class _StartPageState extends State<StartPage> {
                   ),
                   Expanded(
                     child: _loading
-                        ? Center(
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 32,
-                              ),
-                              child: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  MinimoLoader(
-                                    size: 58,
-                                    semanticsLabel: S.of(context).loadingVideos,
-                                  ),
-                                  const SizedBox(height: 18),
-                                  Text(
-                                    S.of(context).loadingVideos,
-                                    textAlign: TextAlign.center,
-                                    style: materialTheme.textTheme.titleMedium
-                                        ?.copyWith(color: theme.textColor),
-                                  ),
-                                  if (_loadingProgress case (
-                                    final done,
-                                    final total,
-                                  )) ...[
-                                    const SizedBox(height: 8),
-                                    Text(
-                                      '$done / $total',
-                                      style: materialTheme.textTheme.titleLarge
-                                          ?.copyWith(color: theme.textColor),
-                                    ),
-                                  ],
-                                  const SizedBox(height: 8),
-                                  Text(
-                                    S.of(context).loadingManyVideosHint,
-                                    textAlign: TextAlign.center,
-                                    style: materialTheme.textTheme.bodyMedium
-                                        ?.copyWith(color: theme.textColor),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          )
+                        ? VideoLoadingView(progress: _loadingProgress)
                         : Center(
                             child: Pressable(
                               child: GestureDetector(

--- a/test/features/compression/compress_bloc_test.dart
+++ b/test/features/compression/compress_bloc_test.dart
@@ -223,6 +223,101 @@ void main() {
     await bloc.close();
   });
 
+  test('adds picked videos while keeping compression settings', () async {
+    final bloc = CompressBloc(
+      initialVideos: const [
+        PickedVideo(path: '/one.mp4', name: 'one.mp4', size: 100),
+      ],
+      videoCompressorAdapter: _EstimatingCompressor(),
+    );
+
+    bloc.add(
+      const CompressSettingsChanged(
+        CompressionSettings(
+          crf: 34,
+          resolution: '854:480',
+          audioMode: CompressionAudioMode.remove,
+        ),
+      ),
+    );
+    await bloc.stream.firstWhere(
+      (state) => state.settings.audioMode == CompressionAudioMode.remove,
+    );
+
+    bloc.add(
+      const CompressVideosAdded([
+        PickedVideo(path: '/two.mp4', name: 'two.mp4', size: 200),
+        PickedVideo(path: '/three.mp4', name: 'three.mp4', size: 300),
+      ]),
+    );
+    await bloc.stream.firstWhere((state) => state.videos.length == 3);
+
+    expect(bloc.state.videos.map((video) => video.name), [
+      'one.mp4',
+      'two.mp4',
+      'three.mp4',
+    ]);
+    expect(bloc.state.thumbnailPaths, hasLength(3));
+    expect(bloc.state.videoStatuses, [
+      VideoCompressionStatus.waiting,
+      VideoCompressionStatus.waiting,
+      VideoCompressionStatus.waiting,
+    ]);
+    expect(bloc.state.settings.resolution, '854:480');
+    expect(bloc.state.settings.audioMode, CompressionAudioMode.remove);
+
+    await bloc.close();
+  });
+
+  test('does not add videos already present in the batch', () async {
+    final bloc = CompressBloc(
+      initialVideos: const [
+        PickedVideo(
+          path: '/cached/original.mp4',
+          name: 'original.mp4',
+          size: 100,
+          sourceIdentifier: 'gallery-id',
+        ),
+        PickedVideo(
+          path: '/cached/document.mov',
+          name: 'document.mov',
+          size: 200,
+        ),
+      ],
+      videoCompressorAdapter: _EstimatingCompressor(),
+    );
+
+    bloc.add(
+      const CompressVideosAdded([
+        PickedVideo(
+          path: '/cached/original_2.mp4',
+          name: 'original.mp4',
+          size: 100,
+          sourceIdentifier: 'gallery-id',
+        ),
+        PickedVideo(
+          path: '/cached/document_2.mov',
+          name: 'document.mov',
+          size: 200,
+        ),
+        PickedVideo(
+          path: '/cached/new-document.mov',
+          name: 'document.mov',
+          size: 300,
+        ),
+      ]),
+    );
+    await bloc.stream.firstWhere((state) => state.videos.length != 2);
+
+    expect(bloc.state.videos.map((video) => video.path), [
+      '/cached/original.mp4',
+      '/cached/document.mov',
+      '/cached/new-document.mov',
+    ]);
+
+    await bloc.close();
+  });
+
   test(
     'cancelling active compression resets state and calls compressor',
     () async {

--- a/test/features/compression/compression_bottom_actions_test.dart
+++ b/test/features/compression/compression_bottom_actions_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minimo_video/features/compression/presentation/widgets/compression_bottom_actions.dart';
+import 'package:minimo_video/generated/l10n.dart';
+import 'package:minimo_video/widgets/app_action_button.dart';
+
+void main() {
+  testWidgets('add action is in the same row as compress', (tester) async {
+    var addCalls = 0;
+    var compressCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: S.delegate.supportedLocales,
+        home: Scaffold(
+          body: CompressionBottomActions(
+            onAdd: () => addCalls++,
+            onCompress: () => compressCalls++,
+          ),
+        ),
+      ),
+    );
+
+    final actions = find.byType(AppActionButton);
+    expect(actions, findsNWidgets(2));
+    expect(
+      tester.getTopLeft(actions.at(0)).dy,
+      tester.getTopLeft(actions.at(1)).dy,
+    );
+
+    await tester.tap(actions.at(0));
+    await tester.tap(find.text('compress'));
+
+    expect(addCalls, 1);
+    expect(compressCalls, 1);
+  });
+}


### PR DESCRIPTION
After toggling all settings on the Settings screen, there is no way to proceed to video selection.
